### PR TITLE
Edge case manifesting in excel sync when employeeId field is missing …

### DIFF
--- a/src/Infrastructure/NetworkPerspective.Sync.Infrastructure.Core/Mappers/IdsMapper.cs
+++ b/src/Infrastructure/NetworkPerspective.Sync.Infrastructure.Core/Mappers/IdsMapper.cs
@@ -11,8 +11,11 @@ namespace NetworkPerspective.Sync.Infrastructure.Core.Mappers
             var result = new Dictionary<string, string>
             {
                 { "Email", employee.IsExternal ? "external" : employee.Id.PrimaryId},
-                { dataSourceIdName, employee.IsExternal ? "external" : employee.Id.DataSourceId},
             };
+            // in some cases, the data source id is not present and we rely only on email
+            // to construct the user id
+            if (employee.Id.DataSourceId is not null)
+                result.Add(dataSourceIdName, employee.IsExternal ? "external" : employee.Id.DataSourceId);
             if (employee.Id.Username is not null && !employee.IsExternal)
                 result.Add("Username", employee.Id.Username);
             return result;


### PR DESCRIPTION
…in source data. When employeeId is not present - simply omit it and do not send it as null.